### PR TITLE
use configured symbol in valuefilter

### DIFF
--- a/bittytax/report.py
+++ b/bittytax/report.py
@@ -70,7 +70,7 @@ class ReportPdf(object):
 
     @staticmethod
     def valuefilter(value):
-        return '&pound;{:0,.2f}'.format(value)
+        return config.sym() + '{:0,.2f}'.format(value)
 
     @staticmethod
     def ratefilter(rate):


### PR DESCRIPTION
This PR fixes the symbol shown in generated reports.

<img width="323" alt="Screen Shot 2021-04-05 at 2 20 38 AM" src="https://user-images.githubusercontent.com/2568174/113559028-8a7d0380-95b5-11eb-9811-a11084f64543.png">
